### PR TITLE
🔧 Preparar despliegue en GitHub Pages y corregir URLs de imágenes en …

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - run: npx ng build --configuration production --base-href /CCAgerec/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: www
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
-/src/environments
 
 # System files
 .DS_Store

--- a/src/app/anadirvgpart/anadirvgpart.component.ts
+++ b/src/app/anadirvgpart/anadirvgpart.component.ts
@@ -5,6 +5,7 @@ import { ToastController } from '@ionic/angular';
 import {FormsModule, NgForm} from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../header/header.component';
+import { environment } from '@environments/environment';
 
 import {
   IonButton,
@@ -111,7 +112,7 @@ export class AnadirvgpartComponent implements OnInit {
       this.maquinaService.anadirCENuevo(maquina, this.tipoMaquina).subscribe({
         next: (res) => {
           if (res.foto) {
-            this.urlFoto = `http://localhost:8000/uploads/${res.foto}`;
+            this.urlFoto = `${environment.apiBase}/uploads/${res.foto}`;
           }
           this.mostrarToast('Máquina con CE nuevo creada correctamente', 'success');
           form.resetForm();

--- a/src/app/anadirvgpartceexistente/anadirvgpartceexistente.component.ts
+++ b/src/app/anadirvgpartceexistente/anadirvgpartceexistente.component.ts
@@ -6,6 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../header/header.component';
 import { Router } from '@angular/router';
+import { environment } from '@environments/environment';
 
 import {
   IonButton,
@@ -139,7 +140,7 @@ export class AnadirvgpartceexistenteComponent implements OnInit {
       .subscribe({
         next: (res:any) => {
           if (res.foto) {
-            this.urlFoto = `http://localhost:8000/uploads/${res.foto}`;
+            this.urlFoto = `${environment.apiBase}/uploads/${res.foto}`;
           }
           this.mostrarToast('Máquina creada con CE existente', 'success');
         },

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { provideRouter } from '@angular/router';
+import { provideRouter, withHashLocation } from '@angular/router';
 import { importProvidersFrom } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app.component';  // <-- Importa el componente aquí
@@ -7,7 +7,9 @@ import { IonicModule } from '@ionic/angular';
 
 bootstrapApplication(AppComponent, {
   providers: [
-    provideRouter(AppRoutes),
+    // withHashLocation: GitHub Pages no puede redirigir rutas al index.html,
+    // así que el router usa '#/ruta' para que las URLs funcionen al refrescar o enlazar directo.
+    provideRouter(AppRoutes, withHashLocation()),
     importProvidersFrom(IonicModule.forRoot()),
   ],
 });

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,10 @@
+export const environment = {
+  production: false,
+  apiBase: 'https://agerecapp.finode.com:8433/backendagerec',
+  endpoints: {
+    user: 'UserAction.php',
+    caja: 'Ccobtenercaja.php',
+    maquina: 'CruceDeReferencia.php'
+  },
+  developerEmail: 'developer@miapp.com' // <-- Cambia este correo si es necesario
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,13 @@
+// This file can be replaced during build by using the fileReplacements array.
+// ng build replaces environment.ts with environment.prod.ts.
+// The list of file replacements can be found in angular.json.
+
+export const environment = {
+  production: false,
+  apiBase: 'https://agerecapp.finode.com:8433/backendagerec',
+  endpoints: {
+    user: 'UserAction.php',
+    caja: 'Ccobtenercaja.php',
+    maquina: 'CruceDeReferencia.php'
+  }
+};


### PR DESCRIPTION
…producción

- Añade workflow de GitHub Actions para build y deploy automático a GitHub Pages
- Activa withHashLocation() en el router (necesario porque GitHub Pages no reescribe rutas)
- Corrige URL de fotos hardcodeada a localhost:8000, ahora usa environment.apiBase
- Versiona src/environments (sin secretos reales, necesario para que el build de CI funcione)